### PR TITLE
Address issues with using MicroBlink in Manual setup

### DIFF
--- a/sdk-device-frameworks/MicroBlink.framework/Headers/MicroBlink.h
+++ b/sdk-device-frameworks/MicroBlink.framework/Headers/MicroBlink.h
@@ -21,5 +21,6 @@
 #import "PPQuadDetectorResult.h"
 
 #import "PPBlinkBarcodeRecognizers.h"
+#import "MicroBlinkDynamic.h"
 
 #endif

--- a/sdk-device-frameworks/MicroBlink.framework/Headers/MicroBlinkDynamic.h
+++ b/sdk-device-frameworks/MicroBlink.framework/Headers/MicroBlinkDynamic.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Jumio Corporation. All rights reserved.
 //
 
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for MicroBlinkDynamic.
 FOUNDATION_EXPORT double MicroBlinkDynamicVersionNumber;
@@ -15,5 +15,3 @@ FOUNDATION_EXPORT double MicroBlinkDynamicVersionNumber;
 FOUNDATION_EXPORT const unsigned char MicroBlinkDynamicVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <MicroBlinkDynamic/PublicHeader.h>
-
-

--- a/sdk-fat-frameworks/MicroBlink.framework/Headers/MicroBlink.h
+++ b/sdk-fat-frameworks/MicroBlink.framework/Headers/MicroBlink.h
@@ -21,5 +21,6 @@
 #import "PPQuadDetectorResult.h"
 
 #import "PPBlinkBarcodeRecognizers.h"
+#import "MicroBlinkDynamic.h"
 
 #endif

--- a/sdk-fat-frameworks/MicroBlink.framework/Headers/MicroBlinkDynamic.h
+++ b/sdk-fat-frameworks/MicroBlink.framework/Headers/MicroBlinkDynamic.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Jumio Corporation. All rights reserved.
 //
 
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for MicroBlinkDynamic.
 FOUNDATION_EXPORT double MicroBlinkDynamicVersionNumber;
@@ -15,5 +15,3 @@ FOUNDATION_EXPORT double MicroBlinkDynamicVersionNumber;
 FOUNDATION_EXPORT const unsigned char MicroBlinkDynamicVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <MicroBlinkDynamic/PublicHeader.h>
-
-


### PR DESCRIPTION
Following the directions for [Manual setup](https://github.com/Jumio/mobile-sdk-ios#manual) were getting errors when trying to import MicroBlink. These changes address the issues.

* MicroBlink wasn't importing MicroBlinkDynamic. 
* MicroBlinkDynamic was importing OSX Cocoa headers instead of iOS Foundation ones