### PR TITLE
Remove empty string in Localizable-Netverify.strings

### DIFF
--- a/sdk-device-frameworks/Localizable-Netverify.strings
+++ b/sdk-device-frameworks/Localizable-Netverify.strings
@@ -83,4 +83,3 @@
 "netverify.submission-view.uploading.headline" = "Uploading your documents";
 "netverify.submission-view.uploading.description" = "This should only take a couple of seconds, depending on your network connectivity";
 "netverify.submission-view.successful.headline" = "Upload successful";
-"netverify.submission-view.successful.description" = "";


### PR DESCRIPTION
When importing localized strings with `xcodebuild`, I get a warning: 
```
--- xcodebuild: WARNING: Vendor/en.lproj/Localizable-Netverify.strings: Incoming translated string is missing (Key: "netverify.submission-view.successful.description")
```

Not critical, but I think there is no point to keep a key without value in this `.strings` file.