### PR TITLE
Add missing 4.0.0 release url

### DIFF
--- a/Carthage/JumioMobileSDK.json
+++ b/Carthage/JumioMobileSDK.json
@@ -19,5 +19,6 @@
  	"3.9.1": "https://mobile-sdk.jumio.com/com/jumio/ios/jumio-mobile-sdk/3.9.1/ios-jumio-mobile-sdk-3.9.1.zip",
  	"3.9.2": "https://mobile-sdk.jumio.com/com/jumio/ios/jumio-mobile-sdk/3.9.2/ios-jumio-mobile-sdk-3.9.2.zip",
  	"3.9.3": "https://mobile-sdk.jumio.com/com/jumio/ios/jumio-mobile-sdk/3.9.3/ios-jumio-mobile-sdk-3.9.3.zip",
- 	"3.9.4": "https://mobile-sdk.jumio.com/com/jumio/ios/jumio-mobile-sdk/3.9.4/ios-jumio-mobile-sdk-3.9.4.zip"
+ 	"3.9.4": "https://mobile-sdk.jumio.com/com/jumio/ios/jumio-mobile-sdk/3.9.4/ios-jumio-mobile-sdk-3.9.4.zip",
+	"4.0.0": "https://mobile-sdk.jumio.com/com/jumio/ios/jumio-mobile-sdk/4.0.0/ios-jumio-mobile-sdk-4.0.0.zip"
 }


### PR DESCRIPTION
Cocoapods is currently broken. pod install is giving an error:

> [!] CocoaPods could not find compatible versions for pod "JumioMobileSDK/NetverifyFace+iProov":
>   In Podfile:
>     JumioMobileSDK/NetverifyFace+iProov (~> 4.0.0)